### PR TITLE
Remove confliction between unused and redefinition

### DIFF
--- a/ftplugin/python/vimpy/vimpy_.py
+++ b/ftplugin/python/vimpy/vimpy_.py
@@ -67,6 +67,7 @@ def _flake_line(line_n):
     undefined = 'undefined'
 
     unused = 'unused'
+    redefinition = 'redefinition'
 
     warnings = StringIO()
 
@@ -93,7 +94,7 @@ def _flake_line(line_n):
 
                 errors[undefined].append(module)
 
-            elif unused in error:
+            elif unused in error and redefinition not in error:
 
                 module = error.split()[1].strip(" |'")
 


### PR DESCRIPTION
PyFlakes will report warning when we redefine variable in our py file, like this:

```
f:21: redefinition of unused 'var' from line 6
```

and you can notice that "unused" keyword is in, so "redefinition" will append to the unused list.

Although there is no module named "redefinition"(who kowns),but remove this confliction will remove some of our doubts.
